### PR TITLE
Add trailing slash to lesson URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ social:
 collections:
   lessons:
     output: true
-    permalink: /:path # path = filename relative
+    permalink: /:path/ # path = filename relative
 
 # Author settings
 author:


### PR DESCRIPTION
* Automatically redirects from `/21` to `/21/`
* Fixes broken links if someone was linking to `/21/`