### PR TITLE
Use absolute urls for links in lesson list, navigation, and ToC

### DIFF
--- a/_includes/lesson-list.html
+++ b/_includes/lesson-list.html
@@ -14,7 +14,7 @@
   {% if lesson.title == skipUntil %}{% assign skipUntil = false %}{% continue %}{% endif %}
   {% if skipUntil %}{% continue %}{% endif %}
   <li>
-    <a href="{{ lesson.url }}">
+    <a href="{{ lesson.url | absolute_url }}">
       {{ lesson.title }}: {{ lesson.subtitle }}
     </a>
   </li>

--- a/_includes/lesson-navigation.html
+++ b/_includes/lesson-navigation.html
@@ -24,17 +24,17 @@
   {% if idxp < 0 %}
   <li></li>
   {% else %}
-  <li><a href="{{ previousLesson.url }}" title="Previous"></a></li>
+  <li><a href="{{ previousLesson.url | absolute_url }}" title="Previous"></a></li>
   {% endif %}
 
   {% unless previousLesson.title == notFound or page.title == tableOfContents %}
-  <li><a href="{{ toc.url }}" title="{{ toc.title }}">ToC</a></li>
+  <li><a href="{{ toc.url | absolute_url }}" title="{{ toc.title }}">ToC</a></li>
   {% endunless %}
 
   {% if idxn >= lessons_count %}
   <li></li>
   {% else %}
-  <li><a href="{{ nextLesson.url }}" title="Next"></a></li>
+  <li><a href="{{ nextLesson.url | absolute_url }}" title="Next"></a></li>
   {% endif %}
 </ul>
 {% else %}
@@ -42,20 +42,20 @@
   {% if idxp < 0 %}
   <li></li>
   {% else %}
-  <li><a href="{{ previousLesson.url }}" title="{{ previousLesson.subtitle }}">
+  <li><a href="{{ previousLesson.url | absolute_url }}" title="{{ previousLesson.subtitle }}">
     {% unless previousLesson.title == tableOfContents %}{{ previousLesson.title }}{% endunless %}
   </a></li>
   {% endif %}
 
   {% unless previousLesson.title == notFound or page.title == tableOfContents %}
-  <li><a href="{{ toc.url }}">{{ toc.title }}</a></li>
+  <li><a href="{{ toc.url | absolute_url }}">{{ toc.title }}</a></li>
   {% endunless %}
 
   {% if idxn >= lessons_count %}
   <li></li>
   {% else %}
   <li>
-    <a href="{{ nextLesson.url }}" title="{{ nextLesson.subtitle }}">
+    <a href="{{ nextLesson.url | absolute_url }}" title="{{ nextLesson.subtitle }}">
     {{ nextLesson.title }}
     </a>
     <img src="{{ 'assets/images/rabbit.webp' | absolute_url }}" title="Follow the white rabbit..."/>

--- a/_includes/lesson-toc.html
+++ b/_includes/lesson-toc.html
@@ -4,7 +4,7 @@
 <ul>
 {% for lesson in pages_sorted %}
   <li>
-    <a href="{{ lesson.url }}">
+    <a href="{{ lesson.url | absolute_url }}">
       {{ lesson.title }}
       {% if lesson.title contains 'Lesson ' or lesson.title contains 'Chapter ' %} : {{ lesson.subtitle }} {% endif %}
     </a>

--- a/ch4-03-translations.md
+++ b/ch4-03-translations.md
@@ -39,7 +39,7 @@ contributions under the same license.
 - 🇯🇵 [Chapter I][jp-philosophy], [Chapter II][jp-economics], and [Chapter III][jp-technology] is available in Japanese thanks to [katakoto].
 - 🇬🇷 [Chapter I][gr-philosophy], [Chapter II][gr-economics], and [Chapter III][gr-technology] is available in Greek thanks to [nikos].
 - 🇮🇷 [Chapter I, Chapter II, and Chapter III][fa-all] is available in Persian thanks to [Nima].
-- 🇮🇩 [Chapter I][id-philosophy] is available in Indonesian thanks to [Hazmi Tri Laksono][hazmi]
+- 🇮🇩 [Chapter I][id-philosophy] and [Chapter II][id-economics] is available in Indonesian thanks to [Hazmi Tri Laksono][hazmi]
 
 <!-- Translations -->
 [es-philosophy]: https://medium.com/@dergigi/ense%C3%B1anzas-filos%C3%B3ficas-de-bitcoin-8ae1357357f9
@@ -66,6 +66,7 @@ contributions under the same license.
 [gr-technology]: https://medium.com/@nikosokin/21-%CE%BC%CE%B1%CE%B8%CE%AE%CE%BC%CE%B1%CF%84%CE%B1-%CE%BA%CE%B5%CF%86%CE%AC%CE%BB%CE%B1%CE%B9%CE%BF-%CE%B9%CE%B9%CE%B9-%CF%84%CE%B5%CF%87%CE%BD%CE%BF%CE%BB%CE%BF%CE%B3%CE%AF%CE%B1-5a2cd7c87059
 [fa-all]: https://arzdigital.com/bitcoin-21-lessons/
 [id-philosophy]: https://medium.com/@hazmitri/21-pelajaran-dari-bitcoin-bagian-pertama-filosofi-86ba0b39e0c
+[id-economics]: https://medium.com/@hazmitri/21-pelajaran-dari-bitcoin-bagian-kedua-ekonomi-e6ba6d9a7a70
 
 <!-- German Translation by Rene from Blocktrainer -->
 [Vorwort]: https://www.blocktrainer.de/2019/12/1-tuerchen-21-lektionen-vorwort/


### PR DESCRIPTION
The problem in the actual set is not evident because the site is under the 
root directory of the domain.

I noticed because I host the translation in Italian under a directory.
I have checked and the proposed change should work in both case.